### PR TITLE
List summaries of posts alongside microposts

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -20,6 +20,7 @@ googleAnalytics          = ""
                                                          # For each image the small version has to have the same filename as the big version.
     footerText           = "Powered by [Hugo](https://gohugo.io). Hosted on [Netlify](https://www.netlify.com)."
     showMicroposts       = true
+    mainSections         = ["posts", "microposts"]
 
 # Metadata
     description          = "The homepage of Paul Strickland, an aerospace engineer working in the UK defence industry" # Max 160 characters show in search results

--- a/content/posts/lockdown-3-weeks.md
+++ b/content/posts/lockdown-3-weeks.md
@@ -6,8 +6,6 @@ draft: false
 tags: ["blog","story","lockdown"]
 ---
 
-## Introduction
-
 At this point, Easter 2020, the UK has been restricted to lockdown conditions for three weeks. Despite not being a particularly extroverted or social person, there have still been some significant changes I've had to make. I thought it would be a good opportunity to reflect on the past few weeks as I prepare for this situation to be last longer.
 
 ## How I have been affected

--- a/content/posts/lockdown-8-weeks.md
+++ b/content/posts/lockdown-8-weeks.md
@@ -7,9 +7,7 @@ draft: false
 tags: ["blog","story","lockdown"]
 ---
 
-## Introduction
-
-It's hard to believe that it's been another five weeks since I [first wrote]({{< ref "lockdown-3-weeks" >}}) about adjusting to life spent mainly at home. Whilst I wouldn't say that it seems completely normal now, it is certainly a lot less strange to live like this than it first felt.
+ It's hard to believe that it's been another five weeks since I [first wrote]({{< ref "lockdown-3-weeks" >}}) about adjusting to life spent mainly at home. Whilst I wouldn't say that it seems completely normal now, it is certainly a lot less strange to live like this than it first felt.
 
 ## How I'm doing
 

--- a/themes/simple/layouts/index.html
+++ b/themes/simple/layouts/index.html
@@ -11,16 +11,16 @@
     <article>{{- .Content -}}</article>
     {{ if .Site.Params.showMicroposts }}
     <section class="microposts">
-        <h2>Recent microposts</h2>
-        {{ with .Site.GetPage "microposts" }}
-        {{ range first 5 .Data.Pages }}
+        <h2>Recent posts</h2>
+        {{ range first 5 (where .Site.RegularPages "Type" "in" site.Params.mainSections) }}
         <article class="micropost">
             <aside class="list-date">
                 <a href="{{.Permalink}}">{{.Date.Format "15:04 on Monday 02 January 2006" }}</a>
             </aside>
-            {{ .Content }}
+            <p>
+                {{ .Summary }}
+            </p>
         </article>
-        {{ end }}
         {{ end }}
     </section>
     {{ end }}


### PR DESCRIPTION
Addresses #7. 
Longer posts use automatic summaries. For neatness I've had to edit two posts that have introduction headings in the summaries.